### PR TITLE
Use base-orphans to import Foldable/Traversable orphan instances

### DIFF
--- a/functor-combo.cabal
+++ b/functor-combo.cabal
@@ -22,7 +22,13 @@ source-repository head
 Library
   hs-Source-Dirs:      src
   Extensions:
-  Build-Depends:       base<5, TypeCompose >= 0.9.4, containers, data-inttrie, lub, type-unary
+  Build-Depends:       base<5
+                     , base-orphans
+                     , containers
+                     , data-inttrie
+                     , lub
+                     , TypeCompose >= 0.9.4
+                     , type-unary
   Exposed-Modules:     
                        FunctorCombo.Strict
                        FunctorCombo.Functor

--- a/src/FunctorCombo/Functor.hs
+++ b/src/FunctorCombo/Functor.hs
@@ -28,6 +28,7 @@ module FunctorCombo.Functor
   ) where
 
 
+import Data.Orphans ()
 import Data.Monoid (Monoid(..))
 import Data.Foldable (Foldable(..))
 import Data.Traversable (Traversable(..))
@@ -111,11 +112,6 @@ instance Functor Void where
 -- 
 -- TODO: replace explicit definition with deriving, when the compiler fix
 -- has been around for a while.
-
-#if !MIN_VERSION_base(4,7,0)
-deriving instance Foldable    (Const b)
-deriving instance Traversable (Const b)
-#endif
 
 -- instance Foldable (Const b) where
 --   -- fold (Const _) = mempty

--- a/src/FunctorCombo/Functor.hs
+++ b/src/FunctorCombo/Functor.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE TypeFamilies, CPP #-}
 
 {-# OPTIONS_GHC -Wall #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 ----------------------------------------------------------------------
 -- |
 -- Module      :  FunctorCombo.Functor


### PR DESCRIPTION
Currently, `functor-combo` defines orphan `Foldable`/`Traversable` instances for `Const a`. However, there are a number of other packages that also define these instances, including [`witherable`](https://github.com/fumieval/witherable/blob/ea39bbf04ce9ef2e12711601c88605276f2af68d/src/Data/Witherable.hs#L125-139), [`semigroupoids`](https://github.com/ekmett/semigroupoids/blob/99ce7a18876da749c49e8ee969ff03a340fb76af/src/Data/Traversable/Instances.hs#L36-56), and [`lens`](https://github.com/ekmett/lens/blob/7af45fb03374ef23a3658c17e692ea475f6bf585/src/Control/Lens/Internal/Instances.hs#L44-70), which means that if anyone were to use any combination of these libraries together on GHC 7.6 or earlier, it would lead to instance conflicts.

To help mitigate this possibility, this pull request imports these instances from the `base-orphans` library (which exports backported instances introduced in later versions of `base`, such as `Foldable (Const a)` and `Traversable (Const a)`). This way, we can keep all of these orphan instances in one package so that `functor-combo`, `witherable`, `semigroupoids`, etc. can coexist.
